### PR TITLE
fix: add explicit dev-dependency to `colorama`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ coverage = "7.6.12"
 mypy = "1.15.0"
 bandit = "1.8.2"
 xenon = "0.9.3"
+colorama = "0.4.6"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
`pip_audit` was failing with the error:

```
⚠️ pip-audit did not return any output
ERROR:pip_audit._virtual_env:internal pip failure: ERROR: In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
    colorama>=0.4.1 from https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl (from radon==6.0.1->-r /home/runner/work/puzzle_generator/puzzle_generator/dev-requirements.txt (line 358))
```

This PR adds an explicit dependency to `colorama` in order to resolve this issue.