### PR TITLE
chore: allow `pytest` params in `generate_coverage_data.sh`

### DIFF
--- a/generate_coverage_data.sh
+++ b/generate_coverage_data.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 omitted_paths="tests/*"
 readonly omitted_paths
 
-poetry run coverage run --branch -m pytest
+poetry run coverage run --branch -m pytest "$@"
 poetry run coverage xml --omit="${omitted_paths}"
 poetry run coverage html --omit="${omitted_paths}"
 poetry run coverage report --omit="${omitted_paths}"


### PR DESCRIPTION
Same as vil02/adv_2024#36.