### PR TITLE
Test Python 3.14 before it is released next week.

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os:
           - ubuntu-24.04
-        python-version: ['3.10', 3.11]
+        python-version: ['3.10', '3.12', '3.14']
 
     steps:
       - name: Checkout
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: ${{matrix.python-version}}
+          allow-prereleases: true
 
       - name: Set up Poetry
         uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
@@ -55,8 +56,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
-        python-version: ['3.10', 3.11]
+          - ubuntu-24.04
+        python-version: ['3.10', '3.12', '3.14']
 
     steps:
       - name: Checkout
@@ -68,6 +69,7 @@ jobs:
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: ${{matrix.python-version}}
+          allow-prereleases: true
 
       - name: Set up Poetry
         uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1


### PR DESCRIPTION
Python v3.14 -- October 7th
* https://www.python.org/download/pre-releases
* https://www.python.org/downloads/release/python-3140rc3
* https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#allow-pre-releases