### PR TITLE
feat: add base85 example

### DIFF
--- a/examples/base85_to_reduce_output_size.py
+++ b/examples/base85_to_reduce_output_size.py
@@ -1,0 +1,19 @@
+"""
+This file illustrates how one can reduce the output size
+by using base85 encoding.
+
+The default encoding is base64.
+"""
+
+from puzzle_generator.create_puzzle import create
+
+_PUZZLE = [
+    "What is 1+1?",
+    "2",
+    "What is my name?",
+    "Piotr",
+    "Congratulations, you solved this quiz!",
+]
+
+# note that the encoding is set to base85
+print(create(_PUZZLE, encoding="base85"))


### PR DESCRIPTION
#386 added support of `base85` encoding. This PR adds an example showing how to use it while generating a puzzle.

Related to:
- #142 